### PR TITLE
First test because it's fast, only then build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,12 +48,12 @@ runs:
 
     - shell: bash
       run: |
-        if [[ ${{ inputs.build_docs }} == "true" ]]; then
-          invoke docs
-        fi
-
         if [[ ${{ inputs.test_docs }} == "true" ]]; then
           invoke testdocs
+        fi
+
+        if [[ ${{ inputs.build_docs }} == "true" ]]; then
+          invoke docs
         fi
 
     - shell: bash


### PR DESCRIPTION
Building docs is very slow, so, best is to run test first (if needed) and only build if tests are successful.