### PR TITLE
Mike default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ runs:
             mike deploy --push --update-aliases $VERSION_TAG latest
 
             # set-default makes sure there's an index.html which points to latest, allow-undefined allows it to work even if the tag is not in the versions.json yet (e.g. first time release)
-            mike set-default latest --allow-undefined
+            mike set-default latest --allow-undefined --push
         fi
   
     # Remove old patches and update the versions.json file

--- a/action.yml
+++ b/action.yml
@@ -159,8 +159,8 @@ runs:
         VERSION_TAG="${{ steps.docs.outputs.current_version }}"
 
         if [[ "${{ steps.docs.outputs.commit_type }}" == "tag" ]]; then
-             # Deploy version tag and update latest alias
-            mike deploy --push --update-aliases $VERSION_TAG latest
+             # Deploy version tag and update latest alias, --set-default makes sure there's an index.html which points to latest
+            mike deploy $VERSION_TAG latest --push --update-aliases --set-default latest --allow-undefined
         fi
   
     # Remove old patches and update the versions.json file

--- a/action.yml
+++ b/action.yml
@@ -159,8 +159,11 @@ runs:
         VERSION_TAG="${{ steps.docs.outputs.current_version }}"
 
         if [[ "${{ steps.docs.outputs.commit_type }}" == "tag" ]]; then
-             # Deploy version tag and update latest alias, --set-default makes sure there's an index.html which points to latest
-            mike deploy $VERSION_TAG latest --push --update-aliases --set-default latest --allow-undefined
+            # Deploy version tag and update latest alias
+            mike deploy --push --update-aliases $VERSION_TAG latest
+
+            # set-default makes sure there's an index.html which points to latest, allow-undefined allows it to work even if the tag is not in the versions.json yet (e.g. first time release)
+            mike set-default latest --allow-undefined
         fi
   
     # Remove old patches and update the versions.json file

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ runs:
             mike deploy --push --update-aliases $VERSION_TAG latest
 
             # set-default makes sure there's an index.html which points to latest, allow-undefined allows it to work even if the tag is not in the versions.json yet (e.g. first time release)
-            mike set-default latest --allow-undefined --push
+            mike set-default latest --push
         fi
   
     # Remove old patches and update the versions.json file


### PR DESCRIPTION
For a first-ever deployment with `mike`, it's necessary to set a default version. this takes care of the creation of a root-level `index.html` file which points to it. In the Sphinx workflow this was done by the docversions.  